### PR TITLE
feat: at the end of every day, timecards that have not clocked out should be set to inactive

### DIFF
--- a/supabase/migrations/20240417005848_daily-timecard-status-correction.sql
+++ b/supabase/migrations/20240417005848_daily-timecard-status-correction.sql
@@ -1,0 +1,3 @@
+create extension if not exists "pg_cron" with schema "public" version '1.4-1';
+
+


### PR DESCRIPTION
```sql
/* If DB timezone is not EST */
/*
  ALTER DATABASE postgres SET timezone TO 'America/New_York';
*/

select cron.schedule (
    'daily-timecard-status-correction',
    '59 23 * * *',
    $$ 
      UPDATE 
        timecards 
      SET 
        is_active = false 
      WHERE 
        ended_at is null
          AND
        verification_code is null
          AND
        is_active = true
      ;
    $$
);
```